### PR TITLE
disable netstring size limit

### DIFF
--- a/txpool/pool.py
+++ b/txpool/pool.py
@@ -480,6 +480,8 @@ class Worker(object):
 
 class WorkerProtocol(NetstringReceiver, ProcessProtocol):
 
+    MAX_LENGTH = sys.maxsize
+
     def __init__(self, worker):
         self.__worker = worker
 


### PR DESCRIPTION
Seems reasonable to disable the size limit altogether, and leave it up to the user.